### PR TITLE
Change Unit to DistanceUnit in Chapter 19/v03

### DIFF
--- a/listings/chap19/v03/integration/DistanceCategory.groovy
+++ b/listings/chap19/v03/integration/DistanceCategory.groovy
@@ -4,15 +4,15 @@ import v03.model.*
 
 class DistanceCategory {
   static Distance getCentimeters(Number num) {
-    new Distance(num, Unit.centimeter)
+    new Distance(num, DistanceUnit.centimeter)
   }
 
   static Distance getMeters(Number num) {
-    new Distance(num, Unit.meter)
+    new Distance(num, DistanceUnit.meter)
   }
 
   static Distance getKilometers(Number num) {
-    new Distance(num, Unit.kilometer)
+    new Distance(num, DistanceUnit.kilometer)
   }
 
   static Distance getCm(Number num) { getCentimeters(num) }

--- a/listings/chap19/v03/model/Distance.groovy
+++ b/listings/chap19/v03/model/Distance.groovy
@@ -5,7 +5,7 @@ import groovy.transform.TupleConstructor
 @TupleConstructor
 class Distance {
   Number amount
-  Unit unit
+  DistanceUnit unit
 
   Speed div(Duration dur) {
     new Speed(amount, unit)

--- a/listings/chap19/v03/model/DistanceUnit.groovy
+++ b/listings/chap19/v03/model/DistanceUnit.groovy
@@ -1,6 +1,6 @@
 package v03.model
 
-enum Unit {
+enum DistanceUnit {
   centimeter('cm', 0.01),
   meter     ( 'm',    1),
   kilometer ('km', 1000)
@@ -8,7 +8,7 @@ enum Unit {
   String abbreviation
   double multiplier
 
-  Unit(String abbr, double mult) {
+  DistanceUnit(String abbr, double mult) {
     this.abbreviation = abbr
     this.multiplier = mult
   }

--- a/listings/chap19/v03/model/Speed.groovy
+++ b/listings/chap19/v03/model/Speed.groovy
@@ -5,7 +5,7 @@ import groovy.transform.TupleConstructor
 @TupleConstructor
 class Speed {
   Number amount
-  Unit unit
+  DistanceUnit unit
 
   String toString() { "$amount $unit/h" }
 }


### PR DESCRIPTION
Code in v3 of DSLs uses the name `Unit` for the class while the book uses `DistanceUnit`. This PR changes the code to match the book
