### PR TITLE
Updated groovyfx dependency

### DIFF
--- a/listings/chap11/Listing_11_16_Groovyfx.groovy
+++ b/listings/chap11/Listing_11_16_Groovyfx.groovy
@@ -1,4 +1,4 @@
-@Grab('org.codehaus.groovyfx:groovyfx:0.3.1')
+@Grab('org.codehaus.groovyfx:groovyfx:0.4.0')
 
 import static groovyx.javafx.GroovyFX.start
 


### PR DESCRIPTION
When I tried to run `Listing_11_16_Groovyfx.groovy`, the example failed. Part of the stacktrace was:

```
Exception in Application start method
Caught: java.lang.RuntimeException: Exception in Application start method
java.lang.RuntimeException: Exception in Application start method
        at com.sun.javafx.application.LauncherImpl.launchApplication1(LauncherImpl.java:917)
        at com.sun.javafx.application.LauncherImpl.lambda$launchApplication$156(LauncherImpl.java:182)
Caused by: java.lang.RuntimeException: Could not init groovyx.javafx.SceneGraphBuilder because of an exception in groovyx.javafx.SceneGraphBuilder.registerControls
        at groovyx.javafx.SceneGraphBuilder.<init>(SceneGraphBuilder.groovy:91)
        at groovyx.javafx.SceneGraphBuilder.<init>(SceneGraphBuilder.groovy)
        at groovyx.javafx.GroovyFX.start(GroovyFX.java:34)
        at com.sun.javafx.application.LauncherImpl.lambda$launchApplication1$163(LauncherImpl.java:863)
        at com.sun.javafx.application.PlatformImpl.lambda$runAndWait$176(PlatformImpl.java:326)
        at com.sun.javafx.application.PlatformImpl.lambda$null$174(PlatformImpl.java:295)
        at com.sun.javafx.application.PlatformImpl.lambda$runLater$175(PlatformImpl.java:294)
        at com.sun.glass.ui.InvokeLaterDispatcher$Future.run(InvokeLaterDispatcher.java:95)
        at com.sun.glass.ui.gtk.GtkApplication._runLoop(Native Method)
        at com.sun.glass.ui.gtk.GtkApplication.lambda$null$50(GtkApplication.java:139)
Caused by: java.lang.reflect.InvocationTargetException
        ... 10 more
Caused by: java.lang.ExceptionInInitializerError
        at groovyx.javafx.SceneGraphBuilder.class$(SceneGraphBuilder.groovy)
        at groovyx.javafx.SceneGraphBuilder.$get$$class$groovyx$javafx$factory$TreeItemFactory(SceneGraphBuilder.groovy)
        at groovyx.javafx.SceneGraphBuilder.registerControls(SceneGraphBuilder.groovy:568)
        ... 10 more
Caused by: groovy.lang.MissingPropertyException: No such property: TREE_ITEM_COUNT_CHANGE_EVENT for class: javafx.scene.control.TreeItem
        at groovyx.javafx.factory.TreeItemFactory.<clinit>(TreeItemFactory.groovy)
        ... 13 more

```

My machine was an Ubuntu 14.04 box running Java Oracle JDK version `1.8.0_60`.  I tried both Groovy `2.4.5` and `2.3.9` with the same results.
This PR bumps the `GroovyFX` dependency to the latest version which results in the example running as expected in both Groovy versions I tried.

_Disclaimer:_ When I tried with Oracle JDK version `1.7.0_80`, everything worked well in all cases (existing code and PR code in combination with both versions of Groovy).

There for it seems like version `0.4.0` of `groovyfx` is the safer way to go, although I do understand that this introduces an inconsistency between the code in the book and the code on GitHub.
